### PR TITLE
[TASK] Do not append usernames and passwords

### DIFF
--- a/Classes/Subugoe/GermaniaSacra/Controller/DataImportController.php
+++ b/Classes/Subugoe/GermaniaSacra/Controller/DataImportController.php
@@ -2359,7 +2359,7 @@ class DataImportController extends ActionController {
 		if (!is_dir(dirname($usernamePasswordFile))) {
 			mkdir(dirname($usernamePasswordFile), 0777, TRUE);
 		}
-		file_put_contents($usernamePasswordFile, $usernamePassword,  FILE_APPEND);
+		file_put_contents($usernamePasswordFile, $usernamePassword);
 	}
 }
 ?>


### PR DESCRIPTION
This removes the functionality that the username/password combination
is always appended to the usernamePassword file which makes it now
easier to find the desired combination instead of moving to the end of
the file.
