### PR TITLE
[TASK] ADWD-1532 Optimize Solr Queue

### DIFF
--- a/Classes/Subugoe/GermaniaSacra/Queue/SolrUpdateJob.php
+++ b/Classes/Subugoe/GermaniaSacra/Queue/SolrUpdateJob.php
@@ -72,6 +72,11 @@ class SolrUpdateJob implements JobInterface {
 	 */
 	public function execute(QueueInterface $queue, Message $message) {
 
+		// only one at the time to avoid stacking of requests
+		if ($queue->count() > 0) {
+			return TRUE;
+		}
+
 		$solrExporter = new DataExportController();
 		$solrExporter->injectSettings($this->settings);
 		$solrExporter->initializeAction();


### PR DESCRIPTION
This resolves the stacking of requests to update the solr which would
be useless, since the whole dataset is exported on each change. So we
check if there is already something on the queue and only add new
requests if there is no request pending.
